### PR TITLE
Add Travis testing with GAP from stable-4.11 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
 matrix:
   include:
     - env: GAPBRANCH=master
+    - env: GAPBRANCH=stable-4.11
     - env: GAPBRANCH=stable-4.10
 
 branches:


### PR DESCRIPTION
This adds tests with GAP stable-4.11 branch. You may want to rebase #82 after merging this.