### PR TITLE
Build nq as it is required by HAP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: c
-
+env:
+  global:
+    # For details how this works, and what other configurations you
+    # can make, please look at <https://github.com/gap-system/pkg-ci-scripts>
+    #- GAP_PKGS_TO_CLONE="SomeOtherPackage"
+    - GAP_PKGS_TO_BUILD="io nq profiling" # note: io and profiling always must be built
+    
 addons:
   apt:
     packages:


### PR DESCRIPTION
Xmod requires HAP, and HAP requires nq. This is why loading XMod failed in #82 
After merging this, you will have to rebase #82.