### PR TITLE
Accommodate correctly pluralized ViewStrings in GAP

### DIFF
--- a/doc/gp2obj.xml
+++ b/doc/gp2obj.xml
@@ -1573,8 +1573,7 @@ gap> e1*e2;
 (11,12)>-(1,2)(4,5)(8,9)->(11,13)
 gap> e2^-1;
 (11,13)>-(1,3)(4,6)(7,9)->(12,13)
-gap> obgp := ObjectGroup( gpd33, (11,12) );
-<group with 1 generators>
+gap> obgp := ObjectGroup( gpd33, (11,12) );;
 gap> GeneratorsOfGroup( obgp )[1];
 (11,13)>-( 1, 3)( 4, 6)( 7, 8)->(11,13)
 gap> Homset( gpd33, (11,12), (11,13) );

--- a/tst/manual/gp2obj.tst
+++ b/tst/manual/gp2obj.tst
@@ -513,8 +513,7 @@ gap> e1*e2;
 (11,12)>-(1,2)(4,5)(8,9)->(11,13)
 gap> e2^-1;
 (11,13)>-(1,3)(4,6)(7,9)->(12,13)
-gap> obgp := ObjectGroup( gpd33, (11,12) );
-<group with 1 generators>
+gap> obgp := ObjectGroup( gpd33, (11,12) );;
 gap> GeneratorsOfGroup( obgp )[1];
 (11,13)>-( 1, 3)( 4, 6)( 7, 8)->(11,13)
 gap> Homset( gpd33, (11,12), (11,13) );


### PR DESCRIPTION
(Note: this is very similar to [the PR I made for the package `XModAlg`](https://github.com/gap-packages/xmodalg/pull/35).)

In a future version of GAP, some nouns will be correctly pluralised to match their number.  For example, the `ViewString` in GAP for `CyclicGroup(3);` is currently `<pc group of size 3 with 1 generators>`, whereas it will soon correctly show `<pc group of size 3 with 1 generator>`.

The changes in this PR maintain the backwards compatibility of this package with GAP, and it ensures that the upcoming changes to GAP on this topic do not affect the package either.

See gap-system/gap#3992 and gap-system/gap#4050 for more context.